### PR TITLE
Fix #113: quiet output on updated docker

### DIFF
--- a/bin/build-docker.sh
+++ b/bin/build-docker.sh
@@ -25,7 +25,7 @@ build_image() {
     #   IPv4 forwarding is disabled. Networking will not work.
     declare flags=( --network=host )
     declare tag=${build_docker_registry:+$build_docker_registry/}$build_image_name:$build_version
-    docker build "${flags[@]}" --rm=true --tag="$tag" .
+    docker build "${flags[@]}" --progress=plain --rm=true --tag="$tag" .
     if [[ $build_docker_post_hook ]]; then
         # execute the hook, but unset it so it doesn't infinitely recurse
         build_push=$build_push build_docker_post_hook= "$build_docker_post_hook" "$tag" "${flags[@]}" "--user=$build_run_user" --rm=true


### PR DESCRIPTION
`docker build` on f36 spews out a lot of repeated information making it hard to understand what's going on. This cleans it up. Tested on f32 as well and confirmed the output looked ok.