### PR TITLE
Fix #122 Doc RADIA_RUN_OCI_CMD and RADIA_RUN_OCI_REGISTRY

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-### Docker Containers for Scientific Codes
+## Containers for Scientific Codes
 
-RadiaSoft provides the following Docker images to support scientific computing.
+RadiaSoft provides the following Open Container Initiative (OCI)
+images to support scientific computing.
 
-#### Installation
+### Installation
 
 The best way to install is to use our
 [automated downloader](https://github.com/radiasoft/download). For example,
@@ -18,7 +19,19 @@ If you are running Windows, you will have to run this command in a
 virtual machine or use the
 [Sirepo development install](https://github.com/radiasoft/sirepo/wiki/Development#pc-install).
 
-#### Images
+### Selecting OCI Run-Time
+
+The default OCI run-time is `docker`, if installed. Otherwise, it will
+try `podman`. These are the only run-times supported. If you have both
+`docker` and `podman` installed and executable by the current user,
+then you can select the runtime by setting `$RADIA_RUN_OCI_CMD`, e.g.
+to force `podman`:
+
+```sh
+export RADIA_RUN_OCI_CMD=podman
+```
+
+### Images
 
 The follow container images are available:
 
@@ -29,18 +42,18 @@ The follow container images are available:
 * [radiasoft/sirepo](https://github.com/radiasoft/sirepo)
   is an web application to simplify the execution of scientific codes.
 
-#### Manifests
+### Manifests
 
-All Docker images contain an `/rsmanifest.json` file, which documents
+All OCI images contain an `/rsmanifest.json` file, which documents
 the image: name, type, verison, and uri.
 
 `radiasoft/beamsim` contains the source code for all the beam
 simulation codes it installs. All codes are documented in
 `/home/vagrant/rsmanifest.json`.
 
-#### Build
+### Build
 
-To build docker image, clone the appropriate container repo and run:
+To build an OCI image, clone the appropriate container repo and run:
 
 ```bash
 git clone https://github.com/radiasoft/container-beamsim
@@ -48,4 +61,12 @@ cd container-beamsim
 radia_run container-build
 ```
 
-The command will finish with instructions how to get the images into docker hub.
+The command will finish with instructions how to get the images into
+Docker Hub. You can change the registry by exporting
+`$RADIA_RUN_OCI_REGISTRY`, e.g. to support
+[Red Hat Quay](https://quay.io):
+
+
+```sh
+export RADIA_RUN_OCI_REGISTRY=quay.io
+```

--- a/bin/build-docker.sh
+++ b/bin/build-docker.sh
@@ -6,10 +6,10 @@
 : ${build_docker_cmd:=/bin/bash}
 : ${build_docker_entrypoint:=}
 : ${build_docker_post_hook:=}
-: ${build_docker_registry:=}
+: ${build_docker_registry:=${RADIA_RUN_OCI_REGISTRY:-}}
 : ${build_docker_user:=}
 : ${build_dockerfile_aux:=}
-: ${build_image_add:='docker pull'}
+: ${build_image_add:="$RADIA_RUN_OCI_CMD pull"}
 : ${build_is_public:=}
 : ${build_push:=}
 # Must be defined by $build_script


### PR DESCRIPTION
- Add RADIA_RUN_OCI_REGISTRY, because build_docker_registry is something that would be set bashrc. RADIA_RUN_* is the "more" public interface.